### PR TITLE
Put cmake_minimum_required before project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-# PROJECT(lzham)
 cmake_minimum_required(VERSION 2.8)
+PROJECT(lzham)
 option(BUILD_X64 "build 64-bit" ON)
 option(BUILD_SHARED_LIBS "build shared/static libs" ON)
 

--- a/lzhamcomp/CMakeLists.txt
+++ b/lzhamcomp/CMakeLists.txt
@@ -1,5 +1,5 @@
-PROJECT(lzhamcomp)
 cmake_minimum_required(VERSION 2.8)
+PROJECT(lzhamcomp)
 option(BUILD_X64 "build 64-bit" TRUE)
 
 message("Initial BUILD_X64=${BUILD_X64}")

--- a/lzhamdecomp/CMakeLists.txt
+++ b/lzhamdecomp/CMakeLists.txt
@@ -1,5 +1,5 @@
-PROJECT(lzhamdecomp)
 cmake_minimum_required(VERSION 2.8)
+PROJECT(lzhamdecomp)
 option(BUILD_X64 "build 64-bit" TRUE)
 
 message("Initial BUILD_X64=${BUILD_X64}")

--- a/lzhamdll/CMakeLists.txt
+++ b/lzhamdll/CMakeLists.txt
@@ -1,5 +1,5 @@
-PROJECT(lzhamdll)
 cmake_minimum_required(VERSION 2.8)
+PROJECT(lzhamdll)
 option(BUILD_X64 "build 64-bit" TRUE)
 
 message("Initial BUILD_X64=${BUILD_X64}")

--- a/lzhamtest/CMakeLists.txt
+++ b/lzhamtest/CMakeLists.txt
@@ -1,5 +1,5 @@
-PROJECT(lzhamtest)
 cmake_minimum_required(VERSION 2.8)
+PROJECT(lzhamtest)
 option(BUILD_X64 "build 64-bit" TRUE)
 
 message("Initial BUILD_X64=${BUILD_X64}")


### PR DESCRIPTION
cmake_minimum_required should appear before PROJECT (see [docs](https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html)) in CMakeLists, so this PR changes that. Having them in the wrong order can cause issues at least for MSVC, similar to what is talked about in [this](https://gitlab.kitware.com/cmake/cmake/-/issues/22671) issue. 

This PR also uncomments the PROJECT statement in the top-level CMakeLists.