### PR TITLE
Fix a x86_64 linux compile error

### DIFF
--- a/lzhamdecomp/lzham_huffman_codes.cpp
+++ b/lzhamdecomp/lzham_huffman_codes.cpp
@@ -3,6 +3,8 @@
 #include "lzham_core.h"
 #include "lzham_huffman_codes.h"
 
+#include <cstdint>
+
 namespace lzham
 {
    struct sym_freq

--- a/lzhamdecomp/lzham_symbol_codec.h
+++ b/lzhamdecomp/lzham_symbol_codec.h
@@ -2,6 +2,7 @@
 // LZHAM is in the Public Domain. Please see the Public Domain declaration at the end of include/lzham.h
 #pragma once
 #include "lzham_prefix_coding.h"
+#include <cstdint>
 
 namespace lzham
 {


### PR DESCRIPTION
```
/home/palaiologos/Desktop/lzham_codec-master/lzhamdecomp/lzham_huffman_codes.cpp: In function ‘bool lzham::generate_huffman_codes(void*, uint, const uint16*, uint8*, uint&, uint&)’:
/home/palaiologos/Desktop/lzham_codec-master/lzhamdecomp/lzham_huffman_codes.cpp:227:26: error: ‘UINT16_MAX’ was not declared in this scope
  227 |             sf.m_right = UINT16_MAX;
      |                          ^~~~~~~~~~

/home/palaiologos/Desktop/lzham_codec-master/lzhamdecomp/lzham_symbol_codec.h:22:35: error: ‘UINT64_MAX’ was not declared in this scope
   22 |    const bit_cost_t cBitCostMax = UINT64_MAX;
      |                                   ^~~~~~~~~~
```